### PR TITLE
docs: fix links and align navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ LeanVibe Agent Hive is a **production-ready** multi-agent orchestration system t
 ## Installation
 
 ### **Prerequisites**
-- Python 3.8+
+- Python 3.12+
 - Git
 - Basic familiarity with command-line tools
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,44 +12,37 @@ Welcome to the comprehensive documentation for the LeanVibe Agent Hive - a produ
 ### 🏗️ Architecture
 - [System Overview](architecture/overview.md) - High-level architecture and concepts
 - [Core Components](architecture/components.md) - Detailed component documentation
-- [Data Flow](architecture/data-flow.md) - How data moves through the system
-- [Multi-Agent Coordination](MULTIAGENT_COORDINATOR_ARCHITECTURE.md) - Agent coordination architecture
+- [Multi-Agent Coordination](architecture/MULTIAGENT_COORDINATOR_ARCHITECTURE.md) - Agent coordination architecture
 
 ### 📖 User Guides
-- [Configuration Guide](guides/configuration.md) - Complete configuration reference
-- [Deployment Guide](../DEPLOYMENT.md) - Production deployment strategies
-- [Troubleshooting Guide](../TROUBLESHOOTING.md) - Common issues and solutions
-- [Workflow Guide](WORKFLOW.md) - Autonomous XP workflow methodology
+- [Configuration Management](guides/security-configuration.md) - Security and configuration
+- [Docker Deployment](guides/docker-deployment.md) - Containerized deployment
+- [Troubleshooting Guide](reference/TROUBLESHOOTING.md) - Common issues and solutions
+- [Workflow Guide](workflows/WORKFLOW.md) - Autonomous XP workflow methodology
 
 ### 🔧 API Reference
-- [API Reference](../API_REFERENCE.md) - Complete API documentation
-- [CLI Commands](CLI_COMMANDS_AND_HOOKS_REFERENCE.md) - Command-line interface reference
-- [Authentication](api/authentication.md) - API authentication and security
-- [Examples](api/examples.md) - Practical API usage examples
+- [API Reference](reference/API_REFERENCE.md) - Complete API documentation
+- [CLI Commands](CLI_COMMANDS.md) - Command-line interface reference
 
 ### 🎓 Tutorials
 - [Medium Clone Tutorial](../tutorials/MEDIUM_CLONE_TUTORIAL.md) - Complete real-world project
-- [Agent Creation Tutorial](tutorials/agent-creation.md) - Create custom agents
-- [Workflow Customization](tutorials/workflow-customization.md) - Customize workflows
-- [Integration Examples](tutorials/integration-examples.md) - Third-party integrations
+- [Agent Creation Tutorial](../tutorials/agent-creation.md) - Create custom agents
+- [Workflow Customization](../tutorials/workflow-customization.md) - Customize workflows
 
 ### 📋 Reference
-- [Configuration Reference](reference/configuration.md) - All configuration options
-- [Error Codes](reference/error-codes.md) - Error codes and solutions
-- [Performance Tuning](reference/performance-tuning.md) - Optimization guide
-- [Migration Guide](reference/migration-guide.md) - Version migration instructions
+- [Troubleshooting Guide](reference/TROUBLESHOOTING.md) - Common issues and solutions
 
 ## Documentation Standards
 
 ### For Contributors
-- [Documentation Standards](DOCUMENTATION_STANDARDS.md) - Writing and formatting guidelines
-- [Documentation Governance](DOCUMENTATION_GOVERNANCE.md) - Governance framework
-- [Templates](templates/) - Standardized documentation templates
+- [Documentation Standards](standards/DOCUMENTATION_STANDARDS.md) - Writing and formatting guidelines
+- [Documentation Governance](governance/DOCUMENTATION_GOVERNANCE.md) - Governance framework
+- [Templates](templates/quick-start-template.md) - Standardized documentation templates
 
 ### Quality Assurance
-- [Documentation Audit Report](../DOCUMENTATION_AUDIT_REPORT.md) - Current state assessment
-- [Feedback Implementation](FEEDBACK_IMPLEMENTATION_WORKFLOW.md) - Feedback processes
-- [Review Workflow](PR_REVIEW_WORKFLOW.md) - Documentation review process
+- [Documentation Audit Report](archived/system-reports-2025/DOCUMENTATION_AUDIT_JULY_2025.md) - Current state assessment
+- [Feedback Implementation](workflows/FEEDBACK_IMPLEMENTATION_WORKFLOW.md) - Feedback processes
+- [Review Workflow](workflows/PR_REVIEW_WORKFLOW.md) - Documentation review process
 
 ## Current Status
 
@@ -80,14 +73,14 @@ Welcome to the comprehensive documentation for the LeanVibe Agent Hive - a produ
 
 ### Quick Help
 - **Installation Issues**: See [Installation Guide](getting-started/installation.md)
-- **Configuration Problems**: Check [Configuration Guide](guides/configuration.md)
-- **API Questions**: Review [API Reference](../API_REFERENCE.md)
-- **Deployment Issues**: Consult [Deployment Guide](../DEPLOYMENT.md)
+- **Configuration Problems**: Check [Configuration Management](guides/security-configuration.md)
+- **API Questions**: Review [API Reference](reference/API_REFERENCE.md)
+- **Deployment Issues**: Consult [Docker Deployment](guides/docker-deployment.md)
 
 ### Contributing
-- **Documentation**: Follow [Documentation Standards](DOCUMENTATION_STANDARDS.md)
-- **Code**: See [Development Guide](../DEVELOPMENT.md)
-- **Issues**: Use [Issue Templates](../github_issue_templates.py)
+- **Documentation**: Follow [Documentation Standards](standards/DOCUMENTATION_STANDARDS.md)
+- **Code**: See [Development Guide](guides/DEVELOPMENT.md)
+- **Issues**: Use [Issue Templates](../scripts/github_issue_templates.py)
 
 ## Version Information
 
@@ -101,8 +94,8 @@ Welcome to the comprehensive documentation for the LeanVibe Agent Hive - a produ
 ### Find What You Need
 - **New Users**: Start with [Quick Start Guide](getting-started/quick-start.md)
 - **Developers**: Begin with [Architecture Overview](architecture/overview.md)
-- **Operators**: Review [Deployment Guide](../DEPLOYMENT.md)
-- **Troubleshooters**: Check [Troubleshooting Guide](../TROUBLESHOOTING.md)
+- **Operators**: Review [Docker Deployment](guides/docker-deployment.md)
+- **Troubleshooters**: Check [Troubleshooting Guide](reference/TROUBLESHOOTING.md)
 
 ### Document Structure
 - **Overview**: High-level concepts and purpose

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -602,14 +602,14 @@ leanvibe queue status --detailed
 ### Learning Path
 1. **Setup**: [Installation Guide](../getting-started/installation.md)
 2. **Basic Usage**: [Quick Start Guide](../getting-started/quick-start.md)
-3. **Configuration**: [Configuration Guide](../guides/configuration.md)
-4. **Deployment**: [Deployment Guide](../guides/deployment.md)
+3. **Configuration**: [Configuration Management](../guides/security-configuration.md)
+4. **Deployment**: [Docker Deployment](../guides/docker-deployment.md) (see `k8s/README.md` for Kubernetes)
 
 ### Advanced Topics
-- [Multi-Agent Coordination Patterns](../MULTIAGENT_COORDINATOR_ARCHITECTURE.md)
-- [Workflow Optimization](../WORKFLOW_OPTIMIZATION_ANALYSIS.md)
-- [Security Configuration](../guides/security.md)
-- [Performance Tuning](../reference/performance-tuning.md)
+- [Multi-Agent Coordination Patterns](../architecture/MULTIAGENT_COORDINATOR_ARCHITECTURE.md)
+- [Workflow Optimization](../workflows/WORKFLOW_OPTIMIZATION_SUMMARY.md)
+- [Security Configuration](../guides/security-configuration.md)
+- [Performance Benchmarks](../guides/BENCHMARKS.md)
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,8 +1,8 @@
 # Agent Hive Architecture Overview
 
-**Version**: 2.0  
-**Last Updated**: July 15, 2025  
-**Status**: Production Ready (Phase 2)  
+**Version**: 4.0  
+**Last Updated**: July 26, 2025  
+**Status**: Production Ready (Phase 4)  
 
 ## Introduction
 
@@ -295,8 +295,8 @@ sequenceDiagram
 ### Monitoring Stack
 - **Prometheus**: Metrics collection and alerting
 - **Grafana**: Visualization and dashboards
-- **Jaeger**: Distributed tracing (planned)
-- **ELK Stack**: Log aggregation and analysis (planned)
+- **Jaeger**: Distributed tracing (integrated)
+- **ELK Stack**: Log aggregation and analysis (optional)
 
 ## Deployment Architecture
 
@@ -349,9 +349,9 @@ The modular design allows for easy extension and customization while the compreh
 
 - [Core Components](components.md) - Detailed component documentation
 - [Data Flow](data-flow.md) - System data flow patterns
-- [Multi-Agent Coordination](../MULTIAGENT_COORDINATOR_ARCHITECTURE.md) - Coordination details
-- [Deployment Guide](../../DEPLOYMENT.md) - Production deployment
-- [API Reference](../../API_REFERENCE.md) - Complete API documentation
+- [Multi-Agent Coordination](MULTIAGENT_COORDINATOR_ARCHITECTURE.md) - Coordination details
+- [Deployment Guide](../guides/docker-deployment.md) - Containerized deployment (see `k8s/README.md` for Kubernetes)
+- [API Reference](../reference/API_REFERENCE.md) - Complete API documentation
 
 ---
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -122,9 +122,9 @@ ls -la tests/
 - [Workflow Customization](../../tutorials/workflow-customization.md) - Customize workflows
 
 ### Advanced Configuration
-- [Configuration Guide](../guides/configuration.md) - Complete configuration reference
-- [Deployment Guide](../../DEPLOYMENT.md) - Production deployment strategies
-- [API Reference](../../API_REFERENCE.md) - Complete API documentation
+- [Configuration Guide](../guides/README.md) - Complete configuration reference
+- [Deployment Guide](../guides/docker-deployment.md) - Production deployment strategies (see `k8s/README.md` for Kubernetes)
+- [API Reference](../reference/API_REFERENCE.md) - Complete API documentation
 
 ## Troubleshooting
 
@@ -140,7 +140,7 @@ ls -la tests/
 **Solution**: Verify installation: `uv sync` and check virtual environment
 
 ### Get Help
-- Check [Troubleshooting Guide](../../TROUBLESHOOTING.md)
+- Check [Troubleshooting Guide](../reference/TROUBLESHOOTING.md)
 - Review [Installation Guide](installation.md)
 - Ask questions in [GitHub Discussions](https://github.com/leanvibe/agent-hive/discussions)
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -42,7 +42,7 @@ This directory contains comprehensive operational guides for deploying, managing
 - Performance monitoring and alerting
 - Team collaboration and notifications
 
-### 📊 [Production Deployment](deployment.md)
+### 📊 [Production Deployment](../operations/DEPLOYMENT.md)
 **High-level deployment strategies and architecture**
 
 - **Kubernetes deployment** configurations
@@ -63,9 +63,9 @@ This directory contains comprehensive operational guides for deploying, managing
 |----------|---------------|-------------------|------------|
 | Local Development | [Docker Deployment](docker-deployment.md) | [CI/CD Operations](cicd-operations.md) | Low |
 | Staging Environment | [Docker Deployment](docker-deployment.md) | [CI/CD Operations](cicd-operations.md) | Medium |
-| Small Production | [Docker Deployment](docker-deployment.md) | [CI/CD Operations](cicd-operations.md), [Deployment](deployment.md) | Medium |
-| Enterprise Production | [Deployment](deployment.md) | [Docker Deployment](docker-deployment.md), [CI/CD Operations](cicd-operations.md) | High |
-| Multi-Cloud | [Deployment](deployment.md) | All guides | High |
+| Small Production | [Docker Deployment](docker-deployment.md) | [CI/CD Operations](cicd-operations.md), [Deployment](../operations/DEPLOYMENT.md) | Medium |
+| Enterprise Production | [Deployment](../operations/DEPLOYMENT.md) | [Docker Deployment](docker-deployment.md), [CI/CD Operations](cicd-operations.md) | High |
+| Multi-Cloud | [Deployment](../operations/DEPLOYMENT.md) | All guides | High |
 
 ## Architecture Decision Matrix
 
@@ -75,7 +75,7 @@ This directory contains comprehensive operational guides for deploying, managing
 |----------|----------|-------|------------|
 | Docker Compose | Development, Small Production | [Docker Deployment](docker-deployment.md) | Low |
 | Docker Swarm | Medium Production | [Docker Deployment](docker-deployment.md) | Medium |
-| Kubernetes | Large Production, Enterprise | [Deployment](deployment.md) | High |
+| Kubernetes | Large Production, Enterprise | [Deployment](../operations/DEPLOYMENT.md) | High |
 
 ### CI/CD Pipeline
 
@@ -92,7 +92,7 @@ This directory contains comprehensive operational guides for deploying, managing
 | Prometheus | Metrics collection | Auto-discovery, scraping | [Docker Deployment](docker-deployment.md) |
 | Grafana | Visualization | Dashboards, alerting | [Docker Deployment](docker-deployment.md) |
 | ELK Stack | Log aggregation | Centralized logging | [Docker Deployment](docker-deployment.md) |
-| Jaeger | Distributed tracing | Performance monitoring | [Deployment](deployment.md) |
+| Jaeger | Distributed tracing | Performance monitoring | [Deployment](../operations/DEPLOYMENT.md) |
 
 ## Implementation Roadmap
 
@@ -260,7 +260,7 @@ act -j test  # Run GitHub Actions locally
 - **Training Programs**: Custom training for development and operations teams
 
 ### Emergency Procedures
-- **Critical Issues**: Follow incident response procedures in [Deployment Guide](deployment.md)
+- **Critical Issues**: Follow incident response procedures in [Deployment Guide](../operations/DEPLOYMENT.md)
 - **Security Incidents**: Contact security team immediately
 - **Data Recovery**: Follow backup and recovery procedures
 - **Escalation**: Contact on-call engineer or team lead


### PR DESCRIPTION
## Summary
- Fix broken and outdated links in docs on top of current main
- Align navigation across `docs/INDEX.md`, architecture files, and guides
- Update Quick Start to reference correct API/Deployment/Troubleshooting paths
- Bump README Python prerequisite to 3.12

## Rationale
Brings main branch link health in line with recent documentation cleanup without introducing large binary files from develop.

## Test plan
- Open `docs/INDEX.md` and verify all links resolve
- Click-through from `docs/getting-started/quick-start.md` Next Steps section
- Validate architecture pages related links
- Run existing link validator if available